### PR TITLE
Ecm ex8 fix

### DIFF
--- a/Creality/Ender 3 V3 Plus/ecm_1.cfg
+++ b/Creality/Ender 3 V3 Plus/ecm_1.cfg
@@ -156,8 +156,8 @@ rotation_distance: 8.003964672
 
 extruder: extruder
 step_pin: cp_ecm_1:PC12
-dir_pin: !cp_ecm_1:PC11
-enable_pin: !cp_ecm_1:PC10
+dir_pin: !cp_ecm_1:PC10
+enable_pin: !cp_ecm_1:PC11
 microsteps: 16
 rotation_distance: 7.851715344
 

--- a/Creality/K1/ecm_1.cfg
+++ b/Creality/K1/ecm_1.cfg
@@ -156,8 +156,8 @@ rotation_distance: 8.003964672
 
 extruder: extruder
 step_pin: cp_ecm_1:PC12
-dir_pin: !cp_ecm_1:PC11
-enable_pin: !cp_ecm_1:PC10
+dir_pin: !cp_ecm_1:PC10
+enable_pin: !cp_ecm_1:PC11
 microsteps: 16
 rotation_distance: 7.851715344
 

--- a/ecm_1.cfg
+++ b/ecm_1.cfg
@@ -156,8 +156,8 @@ rotation_distance: 8.003964672
 
 extruder: extruder
 step_pin: cp_ecm_1:PC12
-dir_pin: !cp_ecm_1:PC11
-enable_pin: !cp_ecm_1:PC10
+dir_pin: !cp_ecm_1:PC10
+enable_pin: !cp_ecm_1:PC11
 microsteps: 16
 rotation_distance: 7.851715344
 

--- a/ecm_2.cfg
+++ b/ecm_2.cfg
@@ -144,8 +144,8 @@ rotation_distance: 8.003964672
 
 extruder: extruder
 step_pin: cp_ecm_2:PC12
-dir_pin: !cp_ecm_2:PC11
-enable_pin: !cp_ecm_2:PC10
+dir_pin: !cp_ecm_2:PC10
+enable_pin: !cp_ecm_2:PC11
 microsteps: 16
 rotation_distance: 7.851715344
 

--- a/ecm_3.cfg
+++ b/ecm_3.cfg
@@ -138,8 +138,8 @@ rotation_distance: 8.003964672
 
 extruder: extruder
 step_pin: cp_ecm_3:PC12
-dir_pin: !cp_ecm_3:PC11
-enable_pin: !cp_ecm_3:PC10
+dir_pin: !cp_ecm_3:PC10
+enable_pin: !cp_ecm_3:PC11
 microsteps: 16
 rotation_distance: 7.851715344
 

--- a/ecm_4.cfg
+++ b/ecm_4.cfg
@@ -1,4 +1,4 @@
-[mcu cp_ecm_4]
+Y789[mcu cp_ecm_4]
 serial: /dev/serial/by-path/platform-xhci-hcd.3.auto-usb-0:1.2:1.0
 restart_method: command
 
@@ -135,8 +135,8 @@ rotation_distance: 8.003964672
 
 extruder: extruder
 step_pin: cp_ecm_4:PC12
-dir_pin: !cp_ecm_4:PC11
-enable_pin: !cp_ecm_4:PC10
+dir_pin: !cp_ecm_4:PC10
+enable_pin: !cp_ecm_4:PC11
 microsteps: 16
 rotation_distance: 7.851715344
 

--- a/ecm_4.cfg
+++ b/ecm_4.cfg
@@ -1,4 +1,4 @@
-Y789[mcu cp_ecm_4]
+[mcu cp_ecm_4]
 serial: /dev/serial/by-path/platform-xhci-hcd.3.auto-usb-0:1.2:1.0
 restart_method: command
 


### PR DESCRIPTION
4th extruder on ecm has the pins for direction and enable inverted. Fixed in all instances 